### PR TITLE
opening a non existent serial, throws an exception trying to close a non opened port!

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -102,6 +102,7 @@ var createModem = function() {
 
         modem.port.on('error', function() {
             modem.close();
+            callback && callback(new Error('Serial port error'));
         });
     }
 


### PR DESCRIPTION
Calling `.close()` on a closed port, raises an exception. This happens when you try to open a non existent port. This patch fixes.
