### PR TITLE
fix constructor Error replaced with new sp(device, options)

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -81,9 +81,9 @@ var createModem = function() {
     modem.open = function(device, options, callback) {
         if (typeof callback === 'function') {
             options['parser'] = sp.parsers.raw;
-            modem.port = new sp.SerialPort(device, options);
+            modem.port = new sp(device, options);
         } else {
-            modem.port = new sp.SerialPort(device, {
+            modem.port = new sp(device, {
                 parser: sp.parsers.raw
             });
             callback = options;


### PR DESCRIPTION
SerialPort don't conatin any sp.SerialPort contructor (module.exports = SerialPort;)
so this line:
modem.port = new sp.SerialPort(device, options);
should be replace with :
modem.port = new sp(device, options);